### PR TITLE
Fix default indent

### DIFF
--- a/lib/dot-json.js
+++ b/lib/dot-json.js
@@ -164,7 +164,7 @@ module.exports = function(file) {
 			throw new Error("File not specified. Set file in constructor or by calling .file('my/path/myfile.json')")
 		}
 
-		if (indent !== 'auto') {
+		if (indent && indent !== 'auto') {
 			this._indent = parseInt(indent);
 		}
 


### PR DESCRIPTION
This change tests the `indent` arg before passing it into `parseInt`, which
fixes a bug where the indent value would become `NaN`, which then caused default
and delete indentation to be lost (instead of preserved as intended).

This also fixes the existing "should be use 2 spaces indents by default
when creating new file" test.